### PR TITLE
Added American Parliamentary 5 Minutes styles

### DIFF
--- a/app/src/main/assets/formats/dapd5.xml
+++ b/app/src/main/assets/formats/dapd5.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<debate-format schema-version="2.1">
+  <name>American Parliamentary 5 Minutes</name>
+  <short-name>APD5</short-name>
+  <info>
+    <region>United States</region>
+    <level>University</level>
+    <used-at>Dutch American Parliamentary Debating</used-at>
+    <description>2 vs 2, POIs allowed, PM LO MG and MO 5 minutes, LO-Whip 3 minutes, PM-Whip 3 minutes</description>
+  </info>
+   <prep-time length="15:00"/>
+  <speech-types>
+    <speech-type ref="pm-const" length="5:00" first-period="normal">
+      <bell time="1:00" number="1" next-period="pois-allowed"/>
+      <bell time="4:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="constructive" length="5:00" first-period="normal">
+      <bell time="1:00" number="1" next-period="pois-allowed"/>
+      <bell time="4:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="lo-Whip" length="3:00" first-period="normal">
+      <bell time="3:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+    <speech-type ref="pm-Whip" length="3:00" first-period="normal">
+      <bell time="3:00" number="1" next-period="warning"/>
+      <bell time="finish" number="2" next-period="overtime"/>
+    </speech-type>
+  </speech-types>
+  <speeches>
+    <speech type="pm-const">
+      <name>Prime Minister's Constructive</name>
+    </speech>
+    <speech type="constructive">
+      <name>Leader of the Opposition's Constructive</name>
+    </speech>
+    <speech type="constructive">
+      <name>Member of the Government</name>
+    </speech>
+    <speech type="constructive">
+      <name>Member of the Opposition</name>
+    </speech>
+    <speech type="lo-Whip">
+      <name>Leader of the Opposition's Whip</name>
+    </speech>
+    <speech type="pm-Whip">
+      <name>Prime Minister's Whip</name>
+    </speech>
+  </speeches>
+</debate-format>


### PR DESCRIPTION
This style is used at many Dutch debating unions and competitions. It would be awesome to add this style to the app! 

At our debating union some people have this custom xml file on their phone. But every time we start a American Parlimentry there is this stressfull moment of searching for a phone that contains this format. It would be much easier if everyone got this style with a app update.

I also notice that in Dutch debating tournaments, a lot of people are using this app to track time in the first four speeches (using the Britisch Parlementary format) and than manually track time for the whip speeches. I feel like adding this format natively to the app would make the debates calmer and more pleasant for everyone.